### PR TITLE
fix(client/http): coalesce simple proxy response into a single Write

### DIFF
--- a/app/internal/http/server.go
+++ b/app/internal/http/server.go
@@ -283,7 +283,12 @@ func sendSimpleResponse(conn net.Conn, req *http.Request, statusCode int) error 
 	// Also, prevent the "Connection: close" header.
 	resp.Close = false
 	resp.Uncompressed = true
-	return resp.Write(conn)
+	var buf bytes.Buffer
+	if err := resp.Write(&buf); err != nil {
+		return err
+	}
+	_, err := conn.Write(buf.Bytes())
+	return err
 }
 
 // sendProxyAuthRequired sends a 407 Proxy Authentication Required response.
@@ -297,5 +302,10 @@ func sendProxyAuthRequired(conn net.Conn, req *http.Request, realm string) error
 		Header:     http.Header{},
 	}
 	resp.Header.Set("Proxy-Authenticate", fmt.Sprintf("Basic realm=%q", realm))
-	return resp.Write(conn)
+	var buf bytes.Buffer
+	if err := resp.Write(&buf); err != nil {
+		return err
+	}
+	_, err := conn.Write(buf.Bytes())
+	return err
 }


### PR DESCRIPTION
Closes #1553.

### What

Make `sendSimpleResponse` and `sendProxyAuthRequired` serialize the response into a `bytes.Buffer` and emit it with a single `conn.Write`, instead of letting Go stdlib `net/http.Response.Write` issue separate writes for the status line and the trailing CRLF.

The wire bytes are unchanged. Only the application-level syscall boundary moves.

### Why

For a CONNECT 200 with `ContentLength=-1` and an empty `Header`, `http.Response.Write` emits two underlying `Write` calls (status line + final CRLF). Because Go sets `TCP_NODELAY=true` on `*net.TCPConn` by default, the bytes go on the wire as **two TCP segments** (`HTTP/1.1 200 OK\r\n` + `\r\n`).

Some real-world HTTP CONNECT clients begin TLS handshake the moment they see the status line + first CRLF and don't tolerate the trailing 2 bytes arriving in a separate segment. The most visible current example is **Bun's x86_64 native build**, which ships in Anthropic's Claude Code CLI: when the response is split, Bun consumes the trailing `\r\n` as TLS data, the TLS record framing is permanently misaligned, and the HTTPS/2 fetch hangs until external timeout. Bun aarch64 is not affected. Full repro and cross-architecture data is in #1553 and in https://github.com/anthropics/claude-code/issues/50252.

This is the same class of fix as #1110 (ffmpeg compatibility): keep the wire bytes identical, just adjust how hy2 hands them to the kernel so a single TCP segment is produced.

### Verification

End-to-end on Linux x86_64 (Ubuntu 24.04.3, kernel 6.8.0-107, hysteria v2.8.1 + this patch, Claude Code 2.1.119 behind hy2):

| Build | Trials | Latency |
|---|---|---|
| v2.8.1 stock | **1/5 OK, 4/5 TIMEOUT** at 45s | timeout |
| v2.8.1 + this PR | **5/5 OK** | 9–15s |

`tcpdump -i lo` on the local hy2 listener:

- before: `Flags [P.], length 17` then `Flags [P.], length 2`
- after: `Flags [P.], length 19` (single segment, exactly `HTTP/1.1 200 OK\r\n\r\n`)

The same change is applied to `sendProxyAuthRequired` so 407 responses with the `Proxy-Authenticate` header are also emitted as a single segment.

### Compatibility

`bytes` is already imported in this file; no new dependencies. The buffered response is at most a few hundred bytes (a CONNECT 200 is exactly 19 bytes), so the extra allocation is negligible.

No behavior change for compliant clients: the wire bytes — including byte order, headers, and content — are byte-for-byte identical.
