### PR TITLE
fix(client): force AF_INET socket when resolvePreference is IPv4

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -271,12 +271,16 @@ func (c *clientConfig) fillConnFactory(hyConfig *client.Config) error {
 	case "", "udp":
 		if hyConfig.ServerAddr.Network() == "udphop" {
 			hopAddr := hyConfig.ServerAddr.(*udphop.UDPHopAddr)
+			network := udpNetworkFromAddr(hopAddr)
 			openInner = func() (net.PacketConn, error) {
-				return udphop.NewUDPHopPacketConn(hopAddr, hopInterval, so.ListenUDP)
+				return udphop.NewUDPHopPacketConn(hopAddr, hopInterval, func() (net.PacketConn, error) {
+					return so.ListenUDPAddrNetwork(network, nil)
+				})
 			}
 		} else {
+			network := udpNetworkFromAddr(hyConfig.ServerAddr)
 			openInner = func() (net.PacketConn, error) {
-				return so.ListenUDP()
+				return so.ListenUDPAddrNetwork(network, nil)
 			}
 		}
 	default:
@@ -1273,6 +1277,32 @@ func punchPacketTypeString(t realm.PunchPacketType) string {
 
 func formatLogDuration(d time.Duration) string {
 	return d.Round(time.Millisecond).String()
+}
+
+// udpNetworkFromAddr returns "udp4" for IPv4, "udp6" for IPv6, "udp" otherwise.
+// This ensures an AF_INET socket is used on IPv4-only interfaces (e.g. Linux GRE tunnels),
+// which silently drop packets from AF_INET6 dual-stack sockets.
+func udpNetworkFromAddr(addr net.Addr) string {
+	var ip net.IP
+	switch a := addr.(type) {
+	case *net.UDPAddr:
+		if a != nil {
+			ip = a.IP
+		}
+	case *udphop.UDPHopAddr:
+		if a != nil {
+			ip = a.IP
+		}
+	default:
+		return "udp"
+	}
+	if ip.To4() != nil {
+		return "udp4"
+	}
+	if len(ip) > 0 {
+		return "udp6"
+	}
+	return "udp"
 }
 
 func connectLog(info *client.HandshakeInfo, count int) {


### PR DESCRIPTION
Fixes #1599.

## Problem

On Linux systems with IPv4-only virtual interfaces like `ip.gre` GRE tunnels,
the Hysteria client fails with:

```
FATAL failed to initialize client {"error": "connect error: timeout: no recent network activity"}
```

The root cause: Go's `net` package defaults to dual-stack `AF_INET6` sockets when
the network type is `"udp"`. Linux GRE tunnels are strictly IPv4 structures and
silently drop outbound UDP packets arriving from an `AF_INET6` socket, causing the
QUIC handshake to time out.

`strace` confirms the issue -- even when the server address is a plain IPv4 address,
the outbound QUIC socket was created as `AF_INET6` and bound to `::`:

```
socket(AF_INET6, SOCK_DGRAM|SOCK_CLOEXEC|SOCK_NONBLOCK, IPPROTO_IP) = 3
bind(3, {sa_family=AF_INET6, ... inet_pton(AF_INET6, "::", ...) ...}, 28) = 0
```

## Fix

After `fillServerAddr` resolves the server address, `fillConnFactory` now inspects
the resolved IP and selects the appropriate UDP network type before opening the
socket:

- IPv4 server → `"udp4"` → `AF_INET` socket
- IPv6 server → `"udp6"` → `AF_INET6` socket

This applies to both the regular UDP path and the port-hopping path.

## Changes

- `fillConnFactory`: pass resolved network type to `so.ListenUDPAddrNetwork`
  instead of the implicit dual-stack `so.ListenUDP`
- add `udpNetworkFromAddr` helper