### PR TITLE
feat(client): dual-stack IPv4/IPv6 racing for hostname-based server addresses

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -237,18 +237,30 @@ func (c *clientConfig) fillServerAddr(hyConfig *client.Config) error {
 	if c.Server == "" {
 		return configError{Field: "server", Err: errors.New("server address is empty")}
 	}
-	var addr net.Addr
-	var err error
 	host, port, hostPort := parseServerAddrString(c.Server)
-	if !isPortHoppingPort(port) {
-		addr, err = net.ResolveUDPAddr("udp", hostPort)
+	if isPortHoppingPort(port) {
+		// Port hopping: resolve immediately (udphop path)
+		addr, err := udphop.ResolveUDPHopAddr(hostPort)
+		if err != nil {
+			return configError{Field: "server", Err: err}
+		}
+		hyConfig.ServerAddr = addr
+	} else if net.ParseIP(host) != nil {
+		// IP literal: resolve immediately
+		addr, err := net.ResolveUDPAddr("udp", hostPort)
+		if err != nil {
+			return configError{Field: "server", Err: err}
+		}
+		hyConfig.ServerAddr = addr
 	} else {
-		addr, err = udphop.ResolveUDPHopAddr(hostPort)
+		// Hostname: defer resolution for native Happy Eyeballs
+		p, err := strconv.Atoi(port)
+		if err != nil {
+			return configError{Field: "server", Err: fmt.Errorf("invalid port: %s", port)}
+		}
+		hyConfig.ServerHost = host
+		hyConfig.ServerPort = uint16(p)
 	}
-	if err != nil {
-		return configError{Field: "server", Err: err}
-	}
-	hyConfig.ServerAddr = addr
 	// Special handling for SNI
 	if c.TLS.SNI == "" {
 		// Use server hostname as SNI
@@ -271,7 +283,7 @@ func (c *clientConfig) fillConnFactory(hyConfig *client.Config) error {
 	var openInner func() (net.PacketConn, error)
 	switch strings.ToLower(c.Transport.Type) {
 	case "", "udp":
-		if hyConfig.ServerAddr.Network() == "udphop" {
+		if hyConfig.ServerAddr != nil && hyConfig.ServerAddr.Network() == "udphop" {
 			hopAddr := hyConfig.ServerAddr.(*udphop.UDPHopAddr)
 			openInner = func() (net.PacketConn, error) {
 				return udphop.NewUDPHopPacketConn(hopAddr, hopInterval, so.ListenUDP)

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	coreErrs "github.com/apernet/hysteria/core/v2/errors"
@@ -21,6 +23,11 @@ import (
 const (
 	closeErrCodeOK            = 0x100 // HTTP3 ErrCodeNoError
 	closeErrCodeProtocolError = 0x101 // HTTP3 ErrCodeGeneralProtocolError
+
+	// happyEyeballsFallbackDelay is the default delay used by Go's
+	// net.Dialer when DualStack is enabled. We replicate it here for
+	// the TCP probe used to select the best address family.
+	happyEyeballsFallbackDelay = 300 * time.Millisecond
 )
 
 type Client interface {
@@ -67,7 +74,55 @@ type clientImpl struct {
 }
 
 func (c *clientImpl) connect() (*HandshakeInfo, error) {
-	pktConn, err := c.config.ConnFactory.New(c.config.ServerAddr)
+	serverAddr := c.config.ServerAddr
+	if serverAddr == nil {
+		// ServerHost mode: use Go's native Happy Eyeballs to race
+		// IPv4 vs IPv6 via a TCP probe, then use the winning IP for QUIC.
+		addr, err := c.resolveWithHappyEyeballs()
+		if err != nil {
+			return nil, coreErrs.ConnectError{Err: err}
+		}
+		serverAddr = addr
+	}
+	return c.connectTo(serverAddr)
+}
+
+// resolveWithHappyEyeballs uses Go's native Happy Eyeballs implementation
+// (net.Dialer with DualStack: true) to race IPv4 and IPv6 TCP connections
+// to the server hostname. The first successful connection's remote IP is
+// then used for the actual QUIC/UDP connection.
+//
+// This leverages the standard library's well-tested dual-stack racing logic
+// instead of implementing it manually.
+func (c *clientImpl) resolveWithHappyEyeballs() (*net.UDPAddr, error) {
+	hostPort := net.JoinHostPort(c.config.ServerHost, strconv.Itoa(int(c.config.ServerPort)))
+	dialer := &net.Dialer{
+		Timeout:       30 * time.Second,
+		KeepAlive:     30 * time.Second,
+		DualStack:     true, // Enable Happy Eyeballs
+		FallbackDelay: happyEyeballsFallbackDelay,
+	}
+	// Dial a TCP connection to the host:port. With DualStack enabled,
+	// Go will concurrently attempt IPv4 and IPv6, returning whichever
+	// connects first.
+	tcpConn, err := dialer.Dial("tcp", hostPort)
+	if err != nil {
+		return nil, fmt.Errorf("happy eyeballs TCP probe failed: %w", err)
+	}
+	defer tcpConn.Close()
+	// Extract the server IP from the established connection
+	remoteAddr := tcpConn.RemoteAddr()
+	tcpAddr, ok := remoteAddr.(*net.TCPAddr)
+	if !ok {
+		return nil, fmt.Errorf("unexpected remote address type: %T", remoteAddr)
+	}
+	return &net.UDPAddr{IP: tcpAddr.IP, Port: int(c.config.ServerPort)}, nil
+}
+
+// connectTo performs the full dial + QUIC handshake + auth flow
+// against the given server address.
+func (c *clientImpl) connectTo(serverAddr net.Addr) (*HandshakeInfo, error) {
+	pktConn, err := c.config.ConnFactory.New(serverAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +155,7 @@ func (c *clientImpl) connect() (*HandshakeInfo, error) {
 		TLSClientConfig: tlsConfig,
 		QUICConfig:      quicConfig,
 		Dial: func(ctx context.Context, _ string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
-			qc, err := tr.DialEarly(ctx, c.config.ServerAddr, tlsCfg, cfg)
+			qc, err := tr.DialEarly(ctx, serverAddr, tlsCfg, cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -169,7 +224,7 @@ func (c *clientImpl) connect() (*HandshakeInfo, error) {
 	return &HandshakeInfo{
 		UDPEnabled:  authResp.UDPEnabled,
 		Tx:          actualTx,
-		ServerAddr:  c.config.ServerAddr,
+		ServerAddr:  serverAddr,
 		ECHAccepted: conn.ConnectionState().TLS.ECHAccepted,
 	}, nil
 }

--- a/core/client/config.go
+++ b/core/client/config.go
@@ -21,6 +21,8 @@ const (
 type Config struct {
 	ConnFactory      ConnFactory
 	ServerAddr       net.Addr
+	ServerHost       string // Hostname for dual-stack racing (used when ServerAddr is nil)
+	ServerPort       uint16 // Port corresponding to ServerHost
 	Auth             string
 	TLSConfig        TLSConfig
 	QUICConfig       QUICConfig
@@ -40,7 +42,7 @@ func (c *Config) verifyAndFill() error {
 	if c.ConnFactory == nil {
 		c.ConnFactory = &udpConnFactory{}
 	}
-	if c.ServerAddr == nil {
+	if c.ServerAddr == nil && c.ServerHost == "" {
 		return errors.ConfigError{Field: "ServerAddr", Reason: "must be set"}
 	}
 	if c.QUICConfig.InitialStreamReceiveWindow == 0 {


### PR DESCRIPTION
Refactor the client connect path to support dual-stack connectivity when the server is specified as a hostname rather than IP literal. The new flow resolves the hostname via DNS, then concurrently dials both IPv4 and IPv6 addresses, using the first successful connection and discarding the loser.