### PR TITLE
fix(extras/obfs): preserve UDP OOB methods through wrappers

### DIFF
--- a/extras/obfs/conn.go
+++ b/extras/obfs/conn.go
@@ -1,10 +1,13 @@
 package obfs
 
 import (
+	"errors"
 	"net"
 	"sync"
 	"syscall"
 	"time"
+
+	"golang.org/x/net/ipv4"
 )
 
 const udpBufferSize = 2048 // QUIC packets are at most 1500 bytes long, so 2k should be more than enough
@@ -41,12 +44,27 @@ type udpLikePacketConn interface {
 	SetWriteBuffer(int) error
 }
 
+type oobCapablePacketConn interface {
+	udpLikePacketConn
+	ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error)
+	WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error)
+}
+
+type oobMessagePacketConn interface {
+	ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error)
+}
+
 // obfsPacketConnUDP is a special case of obfsPacketConn that wraps a
 // UDP-flavored PacketConn. We pass additional methods through to quic-go to
 // enable UDP-specific optimizations.
 type obfsPacketConnUDP struct {
 	*obfsPacketConn
 	UDPConn udpLikePacketConn
+}
+
+type obfsPacketConnOOB struct {
+	*obfsPacketConnUDP
+	OOBConn oobCapablePacketConn
 }
 
 // wrapPacketConn enables per-packet obfuscation on a net.PacketConn.
@@ -59,6 +77,15 @@ func wrapPacketConn(conn net.PacketConn, ob obfuscator) net.PacketConn {
 		Obfs:     ob,
 		readBuf:  make([]byte, udpBufferSize),
 		writeBuf: make([]byte, udpBufferSize),
+	}
+	if oobConn, ok := conn.(oobCapablePacketConn); ok {
+		return &obfsPacketConnOOB{
+			obfsPacketConnUDP: &obfsPacketConnUDP{
+				obfsPacketConn: opc,
+				UDPConn:        oobConn,
+			},
+			OOBConn: oobConn,
+		}
 	}
 	if udpConn, ok := conn.(udpLikePacketConn); ok {
 		return &obfsPacketConnUDP{
@@ -130,4 +157,54 @@ func (c *obfsPacketConnUDP) SetWriteBuffer(bytes int) error {
 
 func (c *obfsPacketConnUDP) SyscallConn() (syscall.RawConn, error) {
 	return c.UDPConn.SyscallConn()
+}
+
+func (c *obfsPacketConnOOB) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error) {
+	for {
+		c.readMutex.Lock()
+		n, oobn, flags, addr, err = c.OOBConn.ReadMsgUDP(c.readBuf, oob)
+		if n <= 0 {
+			c.readMutex.Unlock()
+			return n, oobn, flags, addr, err
+		}
+		n = c.Obfs.Deobfuscate(c.readBuf[:n], b)
+		c.readMutex.Unlock()
+		if n > 0 || err != nil {
+			return n, oobn, flags, addr, err
+		}
+		// Invalid packet, try again
+	}
+}
+
+func (c *obfsPacketConnOOB) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	c.writeMutex.Lock()
+	nn := c.Obfs.Obfuscate(b, c.writeBuf)
+	_, oobn, err = c.OOBConn.WriteMsgUDP(c.writeBuf[:nn], oob, addr)
+	c.writeMutex.Unlock()
+	if err == nil {
+		n = len(b)
+	}
+	return n, oobn, err
+}
+
+func (c *obfsPacketConnOOB) ReadBatch(ms []ipv4.Message, flags int) (int, error) {
+	return readBatchOne(c, ms, flags)
+}
+
+func readBatchOne(c oobMessagePacketConn, ms []ipv4.Message, _ int) (int, error) {
+	if len(ms) == 0 {
+		return 0, nil
+	}
+	if len(ms[0].Buffers) == 0 {
+		return 0, errors.New("obfs: ReadBatch requires a data buffer")
+	}
+	n, oobn, msgFlags, addr, err := c.ReadMsgUDP(ms[0].Buffers[0], ms[0].OOB)
+	if err != nil {
+		return 0, err
+	}
+	ms[0].N = n
+	ms[0].NN = oobn
+	ms[0].Flags = msgFlags
+	ms[0].Addr = addr
+	return 1, nil
 }

--- a/extras/obfs/conn_test.go
+++ b/extras/obfs/conn_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/ipv4"
 )
 
 // fakeUDPLikeConn satisfies udpLikePacketConn without being a *net.UDPConn,
@@ -25,6 +26,31 @@ func (fakeUDPLikeConn) SetWriteDeadline(time.Time) error       { return nil }
 func (fakeUDPLikeConn) SyscallConn() (syscall.RawConn, error)  { return nil, nil }
 func (fakeUDPLikeConn) SetReadBuffer(int) error                { return nil }
 func (fakeUDPLikeConn) SetWriteBuffer(int) error               { return nil }
+
+type fakeOOBConn struct {
+	fakeUDPLikeConn
+
+	readData []byte
+	readOOB  []byte
+	readAddr *net.UDPAddr
+
+	writtenData []byte
+	writtenOOB  []byte
+	writtenAddr *net.UDPAddr
+}
+
+func (c *fakeOOBConn) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error) {
+	n = copy(b, c.readData)
+	oobn = copy(oob, c.readOOB)
+	return n, oobn, 123, c.readAddr, nil
+}
+
+func (c *fakeOOBConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	c.writtenData = append(c.writtenData[:0], b...)
+	c.writtenOOB = append(c.writtenOOB[:0], oob...)
+	c.writtenAddr = addr
+	return len(b), len(oob), nil
+}
 
 type fakePlainConn struct{}
 
@@ -47,8 +73,8 @@ func TestWrapPacketConnUsesUDPVariantForUDPConn(t *testing.T) {
 	defer udp.Close()
 
 	wrapped := wrapPacketConn(udp, noopObfs{})
-	_, ok := wrapped.(*obfsPacketConnUDP)
-	assert.True(t, ok, "wrapping a *net.UDPConn should return *obfsPacketConnUDP")
+	_, ok := wrapped.(*obfsPacketConnOOB)
+	assert.True(t, ok, "wrapping a *net.UDPConn should return *obfsPacketConnOOB")
 }
 
 func TestWrapPacketConnUsesUDPVariantForUDPLikeWrapper(t *testing.T) {
@@ -62,3 +88,42 @@ func TestWrapPacketConnFallsBackForPlainPacketConn(t *testing.T) {
 	_, isUDP := wrapped.(*obfsPacketConnUDP)
 	assert.False(t, isUDP, "wrapping a plain net.PacketConn should not return *obfsPacketConnUDP")
 }
+
+func TestObfsPacketConnOOBReadBatchAndWriteMsgUseWrapper(t *testing.T) {
+	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 443}
+	inner := &fakeOOBConn{
+		readData: []byte("plain"),
+		readOOB:  []byte{1, 2, 3},
+		readAddr: addr,
+	}
+	wrapped := wrapPacketConn(inner, noopObfs{})
+	oobWrapped, ok := wrapped.(interface {
+		oobCapablePacketConn
+		ReadBatch([]ipv4.Message, int) (int, error)
+	})
+	require.True(t, ok, "OOB-capable inner conn should keep quic-go OOB methods")
+
+	buf := make([]byte, 32)
+	oob := make([]byte, 8)
+	msgs := []ipv4.Message{{Buffers: [][]byte{buf}, OOB: oob}}
+	n, err := oobWrapped.ReadBatch(msgs, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, 5, msgs[0].N)
+	require.Equal(t, 3, msgs[0].NN)
+	require.Equal(t, 123, msgs[0].Flags)
+	require.Equal(t, addr, msgs[0].Addr)
+	require.Equal(t, []byte("plain"), buf[:msgs[0].N])
+	require.Equal(t, []byte{1, 2, 3}, oob[:msgs[0].NN])
+
+	_, _, err = oobWrapped.WriteMsgUDP([]byte("reply"), []byte{9, 8}, addr)
+	require.NoError(t, err)
+	require.Equal(t, []byte("reply"), inner.writtenData)
+	require.Equal(t, []byte{9, 8}, inner.writtenOOB)
+	require.Equal(t, addr, inner.writtenAddr)
+}
+
+var _ interface {
+	oobCapablePacketConn
+	ReadBatch([]ipv4.Message, int) (int, error)
+} = (*obfsPacketConnOOB)(nil)

--- a/extras/obfs/gecko.go
+++ b/extras/obfs/gecko.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"golang.org/x/net/ipv4"
 )
 
 // Gecko adds shape obfuscation on top of Salamander: QUIC long-header
@@ -49,7 +51,14 @@ func WrapPacketConnGecko(conn net.PacketConn, opts GeckoOptions) (net.PacketConn
 	if err != nil {
 		return nil, err
 	}
-	return newGeckoPacketConn(inner, minPkt, maxPkt), nil
+	g := newGeckoPacketConn(inner, minPkt, maxPkt)
+	if oobConn, ok := inner.(oobCapablePacketConn); ok {
+		return &geckoPacketConnOOB{
+			geckoPacketConn: g,
+			innerOOB:        oobConn,
+		}, nil
+	}
+	return g, nil
 }
 
 type reassemblyKey struct {
@@ -81,6 +90,11 @@ type geckoPacketConn struct {
 	closeOnce sync.Once
 }
 
+type geckoPacketConnOOB struct {
+	*geckoPacketConn
+	innerOOB oobCapablePacketConn
+}
+
 func newGeckoPacketConn(inner net.PacketConn, minPkt, maxPkt int) *geckoPacketConn {
 	g := &geckoPacketConn{
 		inner:      inner,
@@ -110,6 +124,13 @@ func (g *geckoPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
 }
 
 func (g *geckoPacketConn) writeFragmented(p []byte, addr net.Addr) (int, error) {
+	return g.writeFragmentedWith(p, func(buf []byte) error {
+		_, err := g.inner.WriteTo(buf, addr)
+		return err
+	})
+}
+
+func (g *geckoPacketConn) writeFragmentedWith(p []byte, write func([]byte) error) (int, error) {
 	chunks := randomFragmentChunks()
 	chunkSize := len(p) / chunks
 	msgID := uint8(g.msgID.Add(1))
@@ -131,7 +152,7 @@ func (g *geckoPacketConn) writeFragmented(p []byte, addr net.Addr) (int, error) 
 		if err != nil {
 			return 0, err
 		}
-		if _, err := g.inner.WriteTo(buf[:n], addr); err != nil {
+		if err := write(buf[:n]); err != nil {
 			return 0, err
 		}
 	}
@@ -338,4 +359,61 @@ func (g *geckoPacketConn) SetWriteBuffer(bytes int) error {
 		return u.SetWriteBuffer(bytes)
 	}
 	return errors.ErrUnsupported
+}
+
+func (g *geckoPacketConnOOB) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error) {
+	g.readMu.Lock()
+	defer g.readMu.Unlock()
+	buf := g.readBuf
+	for {
+		n, oobn, flags, addr, err = g.innerOOB.ReadMsgUDP(buf, oob)
+		if err != nil {
+			return 0, oobn, flags, addr, err
+		}
+		if n <= 0 {
+			continue
+		}
+		// Top bit set means Gecko fragment frame; clear means short-header
+		// packet or garbage, passed through for QUIC to handle.
+		if buf[0]&0x80 == 0 {
+			return copy(b, buf[:n]), oobn, flags, addr, nil
+		}
+		h, payload, decErr := decodeFrame(buf[:n])
+		if decErr != nil {
+			// Malformed frame; drop silently.
+			continue
+		}
+		out, ready := g.acceptChunk(addr, h, payload)
+		if !ready {
+			continue
+		}
+		return copy(b, out), oobn, flags, addr, nil
+	}
+}
+
+func (g *geckoPacketConnOOB) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	if len(b) == 0 {
+		return 0, 0, nil
+	}
+	if b[0]&0x80 != 0 {
+		return g.writeFragmentedMsg(b, oob, addr)
+	}
+	n, oobn, err = g.innerOOB.WriteMsgUDP(b, oob, addr)
+	if err == nil {
+		n = len(b)
+	}
+	return n, oobn, err
+}
+
+func (g *geckoPacketConnOOB) writeFragmentedMsg(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	n, err = g.writeFragmentedWith(b, func(buf []byte) error {
+		var writeErr error
+		_, oobn, writeErr = g.innerOOB.WriteMsgUDP(buf, oob, addr)
+		return writeErr
+	})
+	return n, oobn, err
+}
+
+func (g *geckoPacketConnOOB) ReadBatch(ms []ipv4.Message, flags int) (int, error) {
+	return readBatchOne(g, ms, flags)
 }

--- a/extras/obfs/gecko_test.go
+++ b/extras/obfs/gecko_test.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"golang.org/x/net/ipv4"
 )
 
 // --- in-memory packet pipe ---
@@ -486,6 +488,9 @@ func TestGeckoUDPPassthrough(t *testing.T) {
 		SyscallConn() (syscall.RawConn, error)
 		SetReadBuffer(int) error
 		SetWriteBuffer(int) error
+		ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error)
+		WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error)
+		ReadBatch([]ipv4.Message, int) (int, error)
 	}
 	u, ok := g.(udpLike)
 	if !ok {
@@ -561,6 +566,10 @@ func TestGeckoPaddingWithinBounds(t *testing.T) {
 var (
 	_ net.PacketConn    = (*geckoPacketConn)(nil)
 	_ udpLikePacketConn = (*geckoPacketConn)(nil)
+	_ interface {
+		oobCapablePacketConn
+		ReadBatch([]ipv4.Message, int) (int, error)
+	} = (*geckoPacketConnOOB)(nil)
 )
 
 // Sanity: errors.ErrUnsupported is what we return when inner isn't UDP-like.


### PR DESCRIPTION
## Problem

The obfuscation wrappers currently expose the basic `net.PacketConn` and UDP-like methods, but hide `ReadMsgUDP`, `WriteMsgUDP`, and `ReadBatch` even when the underlying connection supports them.

As a result, wrapping a UDP connection prevents downstream users such as quic-go from detecting and using these UDP-specific capabilities.

The same capability loss also occurs after wrapping the connection with Gecko.

## Changes

* Add an OOB-capable obfuscation wrapper for UDP connections.
* Preserve `ReadMsgUDP` and `WriteMsgUDP` while applying packet obfuscation.
* Provide a single-message `ReadBatch` implementation through the wrapper.
* Preserve the same OOB methods through the Gecko wrapper.
* Add unit tests covering OOB reads, writes, metadata propagation, and wrapper capability detection.

## Compatibility

This change does not modify the obfuscation wire format or configuration behavior.

Connections that do not expose the UDP OOB methods continue to use the existing fallback wrappers.
