### PR TITLE
fix: generate dual-stack Mimic filters for wildcard server listeners

### DIFF
--- a/app/cmd/client.go
+++ b/app/cmd/client.go
@@ -1499,7 +1499,7 @@ func (c *clientConfig) startMimic() *mimic.Instance {
 	if !c.Mimic.Enabled {
 		return nil
 	}
-	addr, err := c.mimicServerAddr()
+	addrs, err := c.mimicServerAddrs()
 	if err != nil {
 		logger.Fatal("failed to resolve server address for mimic", zap.Error(err))
 	}
@@ -1511,7 +1511,7 @@ func (c *clientConfig) startMimic() *mimic.Instance {
 			Path:      c.Mimic.Path,
 			ExtraArgs: c.Mimic.ExtraArgs,
 		},
-		mimic.RoleClient, addr, logger,
+		mimic.RoleClient, addrs, logger,
 		func(err error) { logger.Fatal("mimic stopped", zap.Error(err)) },
 	)
 	if err != nil {
@@ -1520,9 +1520,29 @@ func (c *clientConfig) startMimic() *mimic.Instance {
 	return inst
 }
 
-// mimicServerAddr resolves the server address for Mimic's filter. Mimic needs a
-// literal ip:port, so this resolves the name the same way the client will.
-func (c *clientConfig) mimicServerAddr() (*net.UDPAddr, error) {
-	_, _, hostPort := parseServerAddrString(c.Server)
-	return net.ResolveUDPAddr("udp", hostPort)
+// mimicServerAddrs resolves the server address for Mimic's filters. Mimic needs
+// literal ip:port, and a name can resolve to several addresses across both
+// families, so every one of them gets a filter: the client re-resolves on each
+// reconnect and may pick a different one than it did at startup.
+func (c *clientConfig) mimicServerAddrs() ([]*net.UDPAddr, error) {
+	host, portStr, hostPort := parseServerAddrString(c.Server)
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid server port %q: %w", portStr, err)
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return []*net.UDPAddr{{IP: ip, Port: port}}, nil
+	}
+	ips, err := net.DefaultResolver.LookupIP(context.Background(), "ip", host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no addresses for %s", hostPort)
+	}
+	addrs := make([]*net.UDPAddr, 0, len(ips))
+	for _, ip := range ips {
+		addrs = append(addrs, &net.UDPAddr{IP: ip, Port: port})
+	}
+	return addrs, nil
 }

--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -1634,7 +1634,7 @@ func runServer(v *viper.Viper) {
 			Path:      config.Mimic.Path,
 			ExtraArgs: config.Mimic.ExtraArgs,
 		},
-		mimic.RoleServer, listenUDPAddr(config.Listen), logger,
+		mimic.RoleServer, []*net.UDPAddr{listenUDPAddr(config.Listen)}, logger,
 		func(err error) { logger.Fatal("mimic stopped", zap.Error(err)) },
 	)
 	if err != nil {

--- a/app/internal/mimic/mimic_linux.go
+++ b/app/internal/mimic/mimic_linux.go
@@ -53,30 +53,27 @@ func Start(cfg Config, role Role, addr *net.UDPAddr, logger *zap.Logger, onExit 
 	if err != nil {
 		return nil, err
 	}
-	filter := filterFor(role, addr)
+	filters := filtersFor(role, addr)
 	// Mimic attaches to the interface, so one instance serves every client on
 	// this machine reaching the same server.
 	// Reuse it only if its filters cover our address.
 	if pid, ok := runningOn(iface); ok {
-		covered, err := filtersCover(bin, iface, filter)
+		covered, err := filtersCover(bin, iface, filters)
 		if err != nil {
 			return nil, fmt.Errorf("mimic is already running on %s (pid %d) "+
 				"and its filters could not be read: %w", iface, pid, err)
 		}
 		if !covered {
 			return nil, fmt.Errorf("mimic is already running on %s (pid %d) but does "+
-				"not filter %s; stop it, or add that filter to it", iface, pid, filterAddr(filter))
+				"not cover the required filter set (%s); stop it, or update its filters",
+				iface, pid, strings.Join(filterAddrs(filters), ", "))
 		}
 		logger.Info("using the mimic already running on this interface",
 			zap.String("interface", iface), zap.Int("pid", pid))
 		return nil, nil
 	}
 
-	args := []string{"run", iface, "-f", filter}
-	if cfg.XDPMode != "" {
-		args = append(args, "--xdp-mode", cfg.XDPMode)
-	}
-	args = append(args, cfg.ExtraArgs...)
+	args := runArgs(iface, filters, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, bin, args...)
@@ -109,8 +106,19 @@ func Start(cfg Config, role Role, addr *net.UDPAddr, logger *zap.Logger, onExit 
 	}
 	logger.Info("mimic started",
 		zap.String("interface", iface),
-		zap.String("filter", filter))
+		zap.Strings("filters", filters))
 	return i, nil
+}
+
+func runArgs(iface string, filters []string, cfg Config) []string {
+	args := []string{"run", iface}
+	for _, filter := range filters {
+		args = append(args, "-f", filter)
+	}
+	if cfg.XDPMode != "" {
+		args = append(args, "--xdp-mode", cfg.XDPMode)
+	}
+	return append(args, cfg.ExtraArgs...)
 }
 
 // Close stops Mimic and waits for it to detach.
@@ -191,25 +199,38 @@ func runningOn(iface string) (int, bool) {
 
 // filtersCover reports whether the running Mimic already matches our address.
 // "mimic show" prints one "Filter: origin=ip:port" line per whitelist entry.
-func filtersCover(bin, iface, filter string) (bool, error) {
+func filtersCover(bin, iface string, filters []string) (bool, error) {
 	out, err := exec.Command(bin, "show", iface).Output()
 	if err != nil {
 		return false, err
 	}
-	want := filterAddr(filter)
+	covered := make(map[string]bool)
 	for _, line := range strings.Split(stripANSI(string(out)), "\n") {
 		_, v, ok := strings.Cut(line, "Filter:")
-		if ok && filterAddr(strings.TrimSpace(v)) == want {
-			return true, nil
+		if ok {
+			covered[filterAddr(strings.TrimSpace(v))] = true
 		}
 	}
-	return false, nil
+	for _, want := range filterAddrs(filters) {
+		if !covered[want] {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // filterAddr strips the settings a filter may carry, leaving origin=ip:port.
 func filterAddr(filter string) string {
 	addr, _, _ := strings.Cut(filter, ",")
 	return strings.TrimSpace(addr)
+}
+
+func filterAddrs(filters []string) []string {
+	addrs := make([]string, len(filters))
+	for i, filter := range filters {
+		addrs[i] = filterAddr(filter)
+	}
+	return addrs
 }
 
 // lockPID reads the PID from a Mimic lock file, a flat key=value list.
@@ -267,9 +288,16 @@ func waitReady(iface string, ourPID int, exited <-chan struct{}) error {
 	return fmt.Errorf("mimic did not become ready within %s", readyTimeout)
 }
 
-// filterFor builds Mimic's whitelist entry: the client matches on the peer, the
-// server on itself.
-func filterFor(role Role, addr *net.UDPAddr) string {
+// filtersFor builds Mimic's whitelist entries: the client matches on the peer,
+// the server on itself. A server listener with no IP or an IPv6 wildcard
+// accepts both address families, so Mimic needs one local filter for each.
+func filtersFor(role Role, addr *net.UDPAddr) []string {
+	if role == RoleServer && (addr.IP == nil || (addr.IP.IsUnspecified() && addr.IP.To4() == nil)) {
+		return []string{
+			fmt.Sprintf("local=0.0.0.0:%d,handshake=0:3", addr.Port),
+			fmt.Sprintf("local=[::]:%d,handshake=0:3", addr.Port),
+		}
+	}
 	host := addr.IP.String()
 	if addr.IP == nil || addr.IP.IsUnspecified() {
 		host = "0.0.0.0"
@@ -280,9 +308,9 @@ func filterFor(role Role, addr *net.UDPAddr) string {
 	if role == RoleServer {
 		// handshake is interval:retry; interval zero makes this side passive,
 		// so it answers connections but never opens one.
-		return fmt.Sprintf("local=%s:%d,handshake=0:3", host, addr.Port)
+		return []string{fmt.Sprintf("local=%s:%d,handshake=0:3", host, addr.Port)}
 	}
-	return fmt.Sprintf("remote=%s:%d", host, addr.Port)
+	return []string{fmt.Sprintf("remote=%s:%d", host, addr.Port)}
 }
 
 // resolveInterface finds the interface carrying traffic for addr, falling back

--- a/app/internal/mimic/mimic_linux.go
+++ b/app/internal/mimic/mimic_linux.go
@@ -36,24 +36,27 @@ type Instance struct {
 	exited  chan struct{}
 }
 
-// Start launches Mimic for addr and waits for it to attach. addr is the peer's
-// address for RoleClient and our listen address for RoleServer.
-//
+// Start launches Mimic for addrs and waits for it to attach. addrs holds every
+// address the peer resolved to for RoleClient, and our listen address for
+// RoleServer.
 // onExit is called if Mimic stops on its own, which is fatal: the peer expects
 // TCP-shaped packets, so the connection is already dead by then.
-func Start(cfg Config, role Role, addr *net.UDPAddr, logger *zap.Logger, onExit func(error)) (*Instance, error) {
+func Start(cfg Config, role Role, addrs []*net.UDPAddr, logger *zap.Logger, onExit func(error)) (*Instance, error) {
 	if !cfg.Enabled {
 		return nil, nil
+	}
+	if len(addrs) == 0 {
+		return nil, errors.New("mimic needs at least one address to filter")
 	}
 	bin, err := resolveBinary(cfg.Path)
 	if err != nil {
 		return nil, err
 	}
-	iface, err := resolveInterface(cfg.Interface, role, addr)
+	iface, err := resolveInterface(cfg.Interface, role, addrs[0])
 	if err != nil {
 		return nil, err
 	}
-	filters := filtersFor(role, addr)
+	filters := filtersFor(role, addrs)
 	// Mimic attaches to the interface, so one instance serves every client on
 	// this machine reaching the same server.
 	// Reuse it only if its filters cover our address.
@@ -219,10 +222,13 @@ func filtersCover(bin, iface string, filters []string) (bool, error) {
 	return true, nil
 }
 
-// filterAddr strips the settings a filter may carry, leaving origin=ip:port.
+// filterAddr strips everything a filter line may carry beyond origin=ip:port:
+// the settings after a comma, and the "(resolved from <host>)" note that
+// "mimic show" appends when the filter came from a name rather than a literal.
 func filterAddr(filter string) string {
 	addr, _, _ := strings.Cut(filter, ",")
-	return strings.TrimSpace(addr)
+	addr, _, _ = strings.Cut(strings.TrimSpace(addr), " ")
+	return addr
 }
 
 func filterAddrs(filters []string) []string {
@@ -290,27 +296,47 @@ func waitReady(iface string, ourPID int, exited <-chan struct{}) error {
 
 // filtersFor builds Mimic's whitelist entries: the client matches on the peer,
 // the server on itself. A server listener with no IP or an IPv6 wildcard
-// accepts both address families, so Mimic needs one local filter for each.
-func filtersFor(role Role, addr *net.UDPAddr) []string {
-	if role == RoleServer && (addr.IP == nil || (addr.IP.IsUnspecified() && addr.IP.To4() == nil)) {
+// accepts both address families, so Mimic needs one local filter for each. A
+// client gets one filter per address the peer resolved to.
+func filtersFor(role Role, addrs []*net.UDPAddr) []string {
+	if role == RoleClient {
+		filters := make([]string, 0, len(addrs))
+		seen := make(map[string]bool, len(addrs))
+		for _, addr := range addrs {
+			f := fmt.Sprintf("remote=%s:%d", filterHost(addr.IP), addr.Port)
+			if seen[f] {
+				continue
+			}
+			seen[f] = true
+			filters = append(filters, f)
+		}
+		return filters
+	}
+	addr := addrs[0]
+	if addr.IP == nil || (addr.IP.IsUnspecified() && addr.IP.To4() == nil) {
 		return []string{
 			fmt.Sprintf("local=0.0.0.0:%d,handshake=0:3", addr.Port),
 			fmt.Sprintf("local=[::]:%d,handshake=0:3", addr.Port),
 		}
 	}
-	host := addr.IP.String()
-	if addr.IP == nil || addr.IP.IsUnspecified() {
-		host = "0.0.0.0"
+	// handshake is interval:retry; interval zero makes this side passive,
+	// so it answers connections but never opens one.
+	return []string{fmt.Sprintf("local=%s:%d,handshake=0:3", filterHost(addr.IP), addr.Port)}
+}
+
+// filterHost renders an IP the way Mimic's filter syntax expects, bracketing
+// IPv6 so the port stays unambiguous.
+func filterHost(ip net.IP) string {
+	if ip == nil || ip.IsUnspecified() {
+		if ip != nil && ip.To4() == nil {
+			return "[::]"
+		}
+		return "0.0.0.0"
 	}
-	if addr.IP != nil && addr.IP.To4() == nil {
-		host = "[" + host + "]"
+	if ip.To4() == nil {
+		return "[" + ip.String() + "]"
 	}
-	if role == RoleServer {
-		// handshake is interval:retry; interval zero makes this side passive,
-		// so it answers connections but never opens one.
-		return []string{fmt.Sprintf("local=%s:%d,handshake=0:3", host, addr.Port)}
-	}
-	return []string{fmt.Sprintf("remote=%s:%d", host, addr.Port)}
+	return ip.String()
 }
 
 // resolveInterface finds the interface carrying traffic for addr, falling back

--- a/app/internal/mimic/mimic_linux_test.go
+++ b/app/internal/mimic/mimic_linux_test.go
@@ -12,64 +12,85 @@ import (
 
 func TestFiltersFor(t *testing.T) {
 	tests := []struct {
-		name string
-		role Role
-		addr *net.UDPAddr
-		want []string
+		name  string
+		role  Role
+		addrs []*net.UDPAddr
+		want  []string
 	}{
 		{
-			name: "server explicit IPv4",
-			role: RoleServer,
-			addr: &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 58000},
-			want: []string{"local=192.0.2.1:58000,handshake=0:3"},
+			name:  "server explicit IPv4",
+			role:  RoleServer,
+			addrs: []*net.UDPAddr{{IP: net.ParseIP("192.0.2.1"), Port: 58000}},
+			want:  []string{"local=192.0.2.1:58000,handshake=0:3"},
 		},
 		{
-			name: "server explicit IPv6",
-			role: RoleServer,
-			addr: &net.UDPAddr{IP: net.ParseIP("2001:db8::1"), Port: 58000},
-			want: []string{"local=[2001:db8::1]:58000,handshake=0:3"},
+			name:  "server explicit IPv6",
+			role:  RoleServer,
+			addrs: []*net.UDPAddr{{IP: net.ParseIP("2001:db8::1"), Port: 58000}},
+			want:  []string{"local=[2001:db8::1]:58000,handshake=0:3"},
 		},
 		{
-			name: "server nil IP wildcard",
-			role: RoleServer,
-			addr: &net.UDPAddr{Port: 58000},
+			name:  "server nil IP wildcard",
+			role:  RoleServer,
+			addrs: []*net.UDPAddr{{Port: 58000}},
 			want: []string{
 				"local=0.0.0.0:58000,handshake=0:3",
 				"local=[::]:58000,handshake=0:3",
 			},
 		},
 		{
-			name: "server IPv4 wildcard",
-			role: RoleServer,
-			addr: &net.UDPAddr{IP: net.IPv4zero, Port: 58000},
-			want: []string{"local=0.0.0.0:58000,handshake=0:3"},
+			name:  "server IPv4 wildcard",
+			role:  RoleServer,
+			addrs: []*net.UDPAddr{{IP: net.IPv4zero, Port: 58000}},
+			want:  []string{"local=0.0.0.0:58000,handshake=0:3"},
 		},
 		{
-			name: "server IPv6 wildcard",
-			role: RoleServer,
-			addr: &net.UDPAddr{IP: net.IPv6zero, Port: 58000},
+			name:  "server IPv6 wildcard",
+			role:  RoleServer,
+			addrs: []*net.UDPAddr{{IP: net.IPv6zero, Port: 58000}},
 			want: []string{
 				"local=0.0.0.0:58000,handshake=0:3",
 				"local=[::]:58000,handshake=0:3",
 			},
 		},
 		{
-			name: "client IPv4",
+			name:  "client IPv4",
+			role:  RoleClient,
+			addrs: []*net.UDPAddr{{IP: net.ParseIP("192.0.2.1"), Port: 58000}},
+			want:  []string{"remote=192.0.2.1:58000"},
+		},
+		{
+			name:  "client IPv6",
+			role:  RoleClient,
+			addrs: []*net.UDPAddr{{IP: net.ParseIP("2001:db8::1"), Port: 58000}},
+			want:  []string{"remote=[2001:db8::1]:58000"},
+		},
+		{
+			name: "client dual-stack name",
 			role: RoleClient,
-			addr: &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 58000},
+			addrs: []*net.UDPAddr{
+				{IP: net.ParseIP("192.0.2.1"), Port: 58000},
+				{IP: net.ParseIP("2001:db8::1"), Port: 58000},
+			},
+			want: []string{
+				"remote=192.0.2.1:58000",
+				"remote=[2001:db8::1]:58000",
+			},
+		},
+		{
+			name: "client drops duplicate addresses",
+			role: RoleClient,
+			addrs: []*net.UDPAddr{
+				{IP: net.ParseIP("192.0.2.1"), Port: 58000},
+				{IP: net.ParseIP("192.0.2.1"), Port: 58000},
+			},
 			want: []string{"remote=192.0.2.1:58000"},
-		},
-		{
-			name: "client IPv6",
-			role: RoleClient,
-			addr: &net.UDPAddr{IP: net.ParseIP("2001:db8::1"), Port: 58000},
-			want: []string{"remote=[2001:db8::1]:58000"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := filtersFor(tt.role, tt.addr); !reflect.DeepEqual(got, tt.want) {
+			if got := filtersFor(tt.role, tt.addrs); !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("filtersFor() = %v, want %v", got, tt.want)
 			}
 		})
@@ -77,7 +98,7 @@ func TestFiltersFor(t *testing.T) {
 }
 
 func TestRunArgsIncludesEveryFilter(t *testing.T) {
-	filters := filtersFor(RoleServer, &net.UDPAddr{Port: 58000})
+	filters := filtersFor(RoleServer, []*net.UDPAddr{{Port: 58000}})
 	cfg := Config{XDPMode: "skb", ExtraArgs: []string{"--keepalive", "10"}}
 
 	want := []string{
@@ -100,7 +121,7 @@ printf '%s\n' 'Filter: local=0.0.0.0:58000,handshake=0:3'
 		t.Fatal(err)
 	}
 
-	filters := filtersFor(RoleServer, &net.UDPAddr{Port: 58000})
+	filters := filtersFor(RoleServer, []*net.UDPAddr{{Port: 58000}})
 	covered, err := filtersCover(bin, "eth0", filters)
 	if err != nil {
 		t.Fatal(err)
@@ -121,5 +142,24 @@ printf '%s\n' 'Filter: local=[::]:58000,handshake=0:3'
 	}
 	if !covered {
 		t.Fatal("filtersCover() = false with both wildcard-family filters")
+	}
+}
+
+func TestFilterAddrStripsShowAnnotations(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"remote=192.0.2.1:58000", "remote=192.0.2.1:58000"},
+		{"local=0.0.0.0:58000,handshake=0:3", "local=0.0.0.0:58000"},
+		// "mimic show" appends this when the filter came from a name, and does
+		// not print a comma when the settings match the global ones.
+		{"remote=192.0.2.1:58000 (resolved from example.com)", "remote=192.0.2.1:58000"},
+		{"local=[::]:58000,handshake=0:3 (resolved from example.com)", "local=[::]:58000"},
+	}
+	for _, tt := range tests {
+		if got := filterAddr(tt.in); got != tt.want {
+			t.Errorf("filterAddr(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }

--- a/app/internal/mimic/mimic_linux_test.go
+++ b/app/internal/mimic/mimic_linux_test.go
@@ -1,0 +1,125 @@
+//go:build linux
+
+package mimic
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestFiltersFor(t *testing.T) {
+	tests := []struct {
+		name string
+		role Role
+		addr *net.UDPAddr
+		want []string
+	}{
+		{
+			name: "server explicit IPv4",
+			role: RoleServer,
+			addr: &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 58000},
+			want: []string{"local=192.0.2.1:58000,handshake=0:3"},
+		},
+		{
+			name: "server explicit IPv6",
+			role: RoleServer,
+			addr: &net.UDPAddr{IP: net.ParseIP("2001:db8::1"), Port: 58000},
+			want: []string{"local=[2001:db8::1]:58000,handshake=0:3"},
+		},
+		{
+			name: "server nil IP wildcard",
+			role: RoleServer,
+			addr: &net.UDPAddr{Port: 58000},
+			want: []string{
+				"local=0.0.0.0:58000,handshake=0:3",
+				"local=[::]:58000,handshake=0:3",
+			},
+		},
+		{
+			name: "server IPv4 wildcard",
+			role: RoleServer,
+			addr: &net.UDPAddr{IP: net.IPv4zero, Port: 58000},
+			want: []string{"local=0.0.0.0:58000,handshake=0:3"},
+		},
+		{
+			name: "server IPv6 wildcard",
+			role: RoleServer,
+			addr: &net.UDPAddr{IP: net.IPv6zero, Port: 58000},
+			want: []string{
+				"local=0.0.0.0:58000,handshake=0:3",
+				"local=[::]:58000,handshake=0:3",
+			},
+		},
+		{
+			name: "client IPv4",
+			role: RoleClient,
+			addr: &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 58000},
+			want: []string{"remote=192.0.2.1:58000"},
+		},
+		{
+			name: "client IPv6",
+			role: RoleClient,
+			addr: &net.UDPAddr{IP: net.ParseIP("2001:db8::1"), Port: 58000},
+			want: []string{"remote=[2001:db8::1]:58000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filtersFor(tt.role, tt.addr); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("filtersFor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunArgsIncludesEveryFilter(t *testing.T) {
+	filters := filtersFor(RoleServer, &net.UDPAddr{Port: 58000})
+	cfg := Config{XDPMode: "skb", ExtraArgs: []string{"--keepalive", "10"}}
+
+	want := []string{
+		"run", "eth0",
+		"-f", "local=0.0.0.0:58000,handshake=0:3",
+		"-f", "local=[::]:58000,handshake=0:3",
+		"--xdp-mode", "skb",
+		"--keepalive", "10",
+	}
+	if got := runArgs("eth0", filters, cfg); !reflect.DeepEqual(got, want) {
+		t.Fatalf("runArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestFiltersCoverRequiresEveryFilter(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "mimic")
+	if err := os.WriteFile(bin, []byte(`#!/bin/sh
+printf '%s\n' 'Filter: local=0.0.0.0:58000,handshake=0:3'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filters := filtersFor(RoleServer, &net.UDPAddr{Port: 58000})
+	covered, err := filtersCover(bin, "eth0", filters)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if covered {
+		t.Fatal("filtersCover() = true with only one wildcard-family filter")
+	}
+
+	if err := os.WriteFile(bin, []byte(`#!/bin/sh
+printf '%s\n' 'Filter: local=0.0.0.0:58000,handshake=0:3'
+printf '%s\n' 'Filter: local=[::]:58000,handshake=0:3'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	covered, err = filtersCover(bin, "eth0", filters)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !covered {
+		t.Fatal("filtersCover() = false with both wildcard-family filters")
+	}
+}

--- a/app/internal/mimic/mimic_other.go
+++ b/app/internal/mimic/mimic_other.go
@@ -13,7 +13,7 @@ type Instance struct{}
 
 func (i *Instance) Close() error { return nil }
 
-func Start(cfg Config, _ Role, _ *net.UDPAddr, _ *zap.Logger, _ func(error)) (*Instance, error) {
+func Start(cfg Config, _ Role, _ []*net.UDPAddr, _ *zap.Logger, _ func(error)) (*Instance, error) {
 	if !cfg.Enabled {
 		return nil, nil
 	}


### PR DESCRIPTION
Represent the filters derived for a Mimic instance as a collection: clients and explicitly bound servers retain one family-specific filter, while an unspecified server listener produces both IPv4 (`0.0.0.0`) and IPv6 (`[::]`) local filters with the existing passive-handshake settings. Enabling Mimic with the server listening on `:58000` prevents the reporter's IPv6 client from connecting, while the same Hysteria configuration works without Mimic.

A server bound to an explicit IPv4 address generates one `local=<ipv4>:<port>,handshake=0:3` filter, preserving current IPv4 behavior; A server bound to an explicit IPv6 address generates one bracketed `local=[<ipv6>]:<port>,handshake=0:3` filter.

Closes #1661
