### PR TITLE
feat: support Unix sockets for masquerade proxy

### DIFF
--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -55,7 +55,10 @@ import (
 )
 
 const (
-	defaultListenAddr = ":443"
+	defaultListenAddr                  = ":443"
+	masqueradeProxyBufferSize          = 32 * 1024
+	masqueradeProxyMaxIdleConnections  = 100
+	masqueradeProxyMaxIdleConnsPerHost = 32
 )
 
 var serverCmd = &cobra.Command{
@@ -287,6 +290,31 @@ type serverConfigMasqueradeProxy struct {
 	RewriteHost bool   `mapstructure:"rewriteHost"`
 	XForwarded  bool   `mapstructure:"xForwarded"`
 	Insecure    bool   `mapstructure:"insecure"`
+}
+
+type masqueradeProxyBufferPool struct {
+	pool sync.Pool
+}
+
+func newMasqueradeProxyBufferPool() *masqueradeProxyBufferPool {
+	return &masqueradeProxyBufferPool{
+		pool: sync.Pool{
+			New: func() any {
+				return make([]byte, masqueradeProxyBufferSize)
+			},
+		},
+	}
+}
+
+func (p *masqueradeProxyBufferPool) Get() []byte {
+	return p.pool.Get().([]byte)
+}
+
+func (p *masqueradeProxyBufferPool) Put(buf []byte) {
+	if cap(buf) < masqueradeProxyBufferSize {
+		return
+	}
+	p.pool.Put(buf[:masqueradeProxyBufferSize])
 }
 
 type serverConfigMasqueradeString struct {
@@ -1473,6 +1501,99 @@ func (c *serverConfig) fillTrafficLogger(hyConfig *server.Config) error {
 	return nil
 }
 
+func newMasqueradeProxyHandler(config serverConfigMasqueradeProxy) (http.Handler, error) {
+	if config.URL == "" {
+		return nil, errors.New("empty proxy url")
+	}
+	target, transport, err := newMasqueradeProxyTarget(config.URL, config.Insecure)
+	if err != nil {
+		return nil, err
+	}
+	return &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+			// SetURL rewrites the Host header,
+			// but we don't want that if rewriteHost is false
+			if !config.RewriteHost {
+				r.Out.Host = r.In.Host
+			}
+			if config.XForwarded {
+				r.SetXForwarded()
+			}
+		},
+		Transport:  transport,
+		BufferPool: newMasqueradeProxyBufferPool(),
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			logger.Error("HTTP reverse proxy error", zap.Error(err))
+			w.WriteHeader(http.StatusBadGateway)
+		},
+	}, nil
+}
+
+func newMasqueradeProxyTarget(rawURL string, insecure bool) (*url.URL, http.RoundTripper, error) {
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch target.Scheme {
+	case "http", "https":
+		transport := http.DefaultTransport
+		if insecure {
+			tr := http.DefaultTransport.(*http.Transport).Clone()
+			if tr.TLSClientConfig == nil {
+				tr.TLSClientConfig = &tls.Config{}
+			} else {
+				tr.TLSClientConfig = tr.TLSClientConfig.Clone()
+			}
+			tr.TLSClientConfig.InsecureSkipVerify = true
+			transport = tr
+		}
+		return target, transport, nil
+	case "unix":
+		return newUnixMasqueradeProxyTarget(target)
+	case "":
+		if strings.HasPrefix(target.Path, "/") {
+			return newUnixMasqueradeProxyTarget(target)
+		}
+		fallthrough
+	default:
+		return nil, nil, fmt.Errorf("unsupported protocol scheme \"%s\"", target.Scheme)
+	}
+}
+
+func newUnixMasqueradeProxyTarget(parsedURL *url.URL) (*url.URL, http.RoundTripper, error) {
+	if parsedURL.Opaque != "" {
+		return nil, nil, errors.New("invalid unix socket URL: path must be absolute")
+	}
+	if parsedURL.User != nil {
+		return nil, nil, errors.New("invalid unix socket URL: userinfo is not supported")
+	}
+	if parsedURL.Host != "" {
+		return nil, nil, errors.New("invalid unix socket URL: host must be empty")
+	}
+	if parsedURL.RawQuery != "" || parsedURL.ForceQuery || parsedURL.Fragment != "" {
+		return nil, nil, errors.New("invalid unix socket URL: query and fragment are not supported")
+	}
+	if parsedURL.Path == "" {
+		return nil, nil, errors.New("empty unix socket path")
+	}
+	if !strings.HasPrefix(parsedURL.Path, "/") {
+		return nil, nil, errors.New("invalid unix socket URL: path must be absolute")
+	}
+
+	socketPath := parsedURL.Path
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, "unix", socketPath)
+	}
+	transport.MaxIdleConns = masqueradeProxyMaxIdleConnections
+	transport.MaxIdleConnsPerHost = masqueradeProxyMaxIdleConnsPerHost
+
+	return &url.URL{Scheme: "http", Host: "localhost"}, transport, nil
+}
+
 // fillMasqHandler must be called after fillConn, as we may need to extract the QUIC
 // port number from Conn for MasqTCPServer.
 func (c *serverConfig) fillMasqHandler(hyConfig *server.Config) error {
@@ -1486,52 +1607,10 @@ func (c *serverConfig) fillMasqHandler(hyConfig *server.Config) error {
 		}
 		handler = http.FileServer(http.Dir(c.Masquerade.File.Dir))
 	case "proxy":
-		if c.Masquerade.Proxy.URL == "" {
-			return configError{Field: "masquerade.proxy.url", Err: errors.New("empty proxy url")}
-		}
-		u, err := url.Parse(c.Masquerade.Proxy.URL)
+		var err error
+		handler, err = newMasqueradeProxyHandler(c.Masquerade.Proxy)
 		if err != nil {
 			return configError{Field: "masquerade.proxy.url", Err: err}
-		}
-		if u.Scheme != "http" && u.Scheme != "https" {
-			return configError{Field: "masquerade.proxy.url", Err: fmt.Errorf("unsupported protocol scheme \"%s\"", u.Scheme)}
-		}
-		transport := http.DefaultTransport
-		if c.Masquerade.Proxy.Insecure {
-			transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-				// use default configs from http.DefaultTransport
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).DialContext,
-				ForceAttemptHTTP2:     true,
-				MaxIdleConns:          100,
-				IdleConnTimeout:       90 * time.Second,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-			}
-		}
-		handler = &httputil.ReverseProxy{
-			Rewrite: func(r *httputil.ProxyRequest) {
-				r.SetURL(u)
-				// SetURL rewrites the Host header,
-				// but we don't want that if rewriteHost is false
-				if !c.Masquerade.Proxy.RewriteHost {
-					r.Out.Host = r.In.Host
-				}
-				if c.Masquerade.Proxy.XForwarded {
-					r.SetXForwarded()
-				}
-			},
-			Transport: transport,
-			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-				logger.Error("HTTP reverse proxy error", zap.Error(err))
-				w.WriteHeader(http.StatusBadGateway)
-			},
 		}
 	case "string":
 		if c.Masquerade.String.Content == "" {

--- a/app/cmd/server_masquerade_benchmark_test.go
+++ b/app/cmd/server_masquerade_benchmark_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"sync/atomic"
+	"testing"
+)
+
+type discardBenchmarkResponseWriter struct {
+	header http.Header
+	status int
+}
+
+func (w *discardBenchmarkResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *discardBenchmarkResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *discardBenchmarkResponseWriter) Write(body []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return len(body), nil
+}
+
+func BenchmarkMasqueradeProxy(b *testing.B) {
+	payload := make([]byte, 4*1024)
+	upstreamHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	})
+	socketPath, _ := startUnixHTTPServer(b, upstreamHandler)
+	tcpServer := httptest.NewServer(upstreamHandler)
+	b.Cleanup(tcpServer.Close)
+
+	for _, test := range []struct {
+		name       string
+		target     string
+		bufferPool bool
+		cloneTCP   bool
+	}{
+		{name: "unix_pooled_buffer", target: socketPath, bufferPool: true},
+		{name: "tcp_32_idle_pooled_buffer", target: tcpServer.URL, bufferPool: true, cloneTCP: true},
+		{name: "unix_unpooled_buffer", target: socketPath, bufferPool: false},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			handler, err := newMasqueradeProxyHandler(serverConfigMasqueradeProxy{URL: test.target})
+			if err != nil {
+				b.Fatal(err)
+			}
+			proxy := handler.(*httputil.ReverseProxy)
+			transport := proxy.Transport.(*http.Transport)
+			if test.cloneTCP {
+				transport = transport.Clone()
+				transport.MaxIdleConns = masqueradeProxyMaxIdleConnections
+				transport.MaxIdleConnsPerHost = masqueradeProxyMaxIdleConnsPerHost
+				proxy.Transport = transport
+			}
+			b.Cleanup(transport.CloseIdleConnections)
+			if !test.bufferPool {
+				proxy.BufferPool = nil
+			}
+
+			var failures atomic.Int64
+			var firstFailure atomic.Pointer[string]
+			proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+				message := err.Error()
+				firstFailure.CompareAndSwap(nil, &message)
+				w.WriteHeader(http.StatusBadGateway)
+			}
+			b.SetBytes(int64(len(payload)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					request := httptest.NewRequest(http.MethodGet, "https://front.example/resource", nil)
+					response := &discardBenchmarkResponseWriter{header: make(http.Header)}
+					proxy.ServeHTTP(response, request)
+					if response.status != http.StatusOK {
+						failures.Add(1)
+					}
+				}
+			})
+			b.StopTimer()
+			if count := failures.Load(); count != 0 {
+				message := firstFailure.Load()
+				if message == nil {
+					b.Fatalf("%d proxy requests failed", count)
+				}
+				b.Fatalf("%d proxy requests failed: %s", count, *message)
+			}
+		})
+	}
+}

--- a/app/cmd/server_masquerade_test.go
+++ b/app/cmd/server_masquerade_test.go
@@ -1,0 +1,227 @@
+package cmd
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/apernet/hysteria/core/v2/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type countingListener struct {
+	net.Listener
+	accepts atomic.Int64
+}
+
+func (l *countingListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err == nil {
+		l.accepts.Add(1)
+	}
+	return conn, err
+}
+
+type observedProxyRequest struct {
+	Host            string
+	Path            string
+	RawQuery        string
+	XForwardedFor   string
+	XForwardedHost  string
+	XForwardedProto string
+}
+
+func startUnixHTTPServer(tb testing.TB, handler http.Handler) (string, *countingListener) {
+	tb.Helper()
+	if runtime.GOOS == "windows" {
+		tb.Skip("Unix domain sockets are not supported by this test on Windows")
+	}
+	dir, err := os.MkdirTemp("/tmp", "hysteria-masq-uds-")
+	require.NoError(tb, err)
+	tb.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			tb.Errorf("remove Unix socket test directory: %v", err)
+		}
+	})
+	socketPath := filepath.Join(dir, "upstream.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(tb, err)
+	counting := &countingListener{Listener: listener}
+	upstreamServer := &http.Server{Handler: handler}
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- upstreamServer.Serve(counting)
+	}()
+	tb.Cleanup(func() {
+		if err := upstreamServer.Close(); err != nil {
+			tb.Errorf("close Unix socket HTTP server: %v", err)
+		}
+		if err := <-serveErr; err != nil && err != http.ErrServerClosed {
+			tb.Errorf("serve Unix socket HTTP server: %v", err)
+		}
+	})
+	return socketPath, counting
+}
+
+func TestMasqueradeProxyUnixURLStyles(t *testing.T) {
+	observed := make(chan observedProxyRequest, 3)
+	socketPath, _ := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed <- observedProxyRequest{
+			Host:            r.Host,
+			Path:            r.URL.Path,
+			RawQuery:        r.URL.RawQuery,
+			XForwardedFor:   r.Header.Get("X-Forwarded-For"),
+			XForwardedHost:  r.Header.Get("X-Forwarded-Host"),
+			XForwardedProto: r.Header.Get("X-Forwarded-Proto"),
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("proxied"))
+	}))
+
+	tests := []struct {
+		name        string
+		url         string
+		rewriteHost bool
+		wantHost    string
+	}{
+		{name: "absolute path", url: socketPath, wantHost: "front.example"},
+		{name: "single slash Unix URL", url: "unix:" + socketPath, wantHost: "front.example"},
+		{name: "triple slash Unix URL", url: "unix://" + socketPath, rewriteHost: true, wantHost: "localhost"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler, err := newMasqueradeProxyHandler(serverConfigMasqueradeProxy{
+				URL:         test.url,
+				RewriteHost: test.rewriteHost,
+				XForwarded:  true,
+			})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, "https://front.example/assets/app.js?v=7", nil)
+			req.Host = "front.example"
+			req.RemoteAddr = "198.51.100.7:43210"
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+
+			response := recorder.Result()
+			defer response.Body.Close()
+			body, err := io.ReadAll(response.Body)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusCreated, response.StatusCode)
+			assert.Equal(t, "proxied", string(body))
+
+			got := <-observed
+			assert.Equal(t, test.wantHost, got.Host)
+			assert.Equal(t, "/assets/app.js", got.Path)
+			assert.Equal(t, "v=7", got.RawQuery)
+			assert.Equal(t, "198.51.100.7", got.XForwardedFor)
+			assert.Equal(t, "front.example", got.XForwardedHost)
+			assert.Equal(t, "https", got.XForwardedProto)
+		})
+	}
+}
+
+func TestMasqueradeProxyUnixReusesConnections(t *testing.T) {
+	socketPath, listener := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	handler, err := newMasqueradeProxyHandler(serverConfigMasqueradeProxy{URL: socketPath})
+	require.NoError(t, err)
+
+	for range 20 {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "https://front.example/", nil))
+		assert.Equal(t, http.StatusOK, recorder.Code)
+	}
+	assert.Equal(t, int64(1), listener.accepts.Load())
+}
+
+func TestMasqueradeProxyUnixTransportSettings(t *testing.T) {
+	target, roundTripper, err := newMasqueradeProxyTarget("/tmp/anubis.sock", false)
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost", target.String())
+
+	transport, ok := roundTripper.(*http.Transport)
+	require.True(t, ok)
+	assert.Nil(t, transport.Proxy)
+	assert.NotNil(t, transport.DialContext)
+	assert.Equal(t, masqueradeProxyMaxIdleConnections, transport.MaxIdleConns)
+	assert.Equal(t, masqueradeProxyMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+}
+
+func TestMasqueradeProxyUnixConnectionErrorReturnsBadGateway(t *testing.T) {
+	previousLogger := logger
+	logger = zap.NewNop()
+	t.Cleanup(func() { logger = previousLogger })
+
+	handler, err := newMasqueradeProxyHandler(serverConfigMasqueradeProxy{URL: "/tmp/hysteria-missing-anubis.sock"})
+	require.NoError(t, err)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "https://front.example/", nil))
+	assert.Equal(t, http.StatusBadGateway, recorder.Code)
+}
+
+func TestMasqueradeProxyURLValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		{name: "empty", wantErr: "empty proxy url"},
+		{name: "relative path", url: "run/anubis.sock", wantErr: `unsupported protocol scheme ""`},
+		{name: "unknown scheme", url: "ftp://127.0.0.1", wantErr: `unsupported protocol scheme "ftp"`},
+		{name: "Unix host", url: "unix://run/anubis.sock", wantErr: "invalid unix socket URL: host must be empty"},
+		{name: "Unix userinfo", url: "unix://user@/run/anubis.sock", wantErr: "invalid unix socket URL: userinfo is not supported"},
+		{name: "Unix query", url: "unix:///run/anubis.sock?mode=1", wantErr: "invalid unix socket URL: query and fragment are not supported"},
+		{name: "Unix fragment", url: "unix:///run/anubis.sock#fragment", wantErr: "invalid unix socket URL: query and fragment are not supported"},
+		{name: "Unix opaque relative path", url: "unix:run/anubis.sock", wantErr: "invalid unix socket URL: path must be absolute"},
+		{name: "empty Unix path", url: "unix://", wantErr: "empty unix socket path"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := &serverConfig{Masquerade: serverConfigMasquerade{
+				Type:  "proxy",
+				Proxy: serverConfigMasqueradeProxy{URL: test.url},
+			}}
+			err := config.fillMasqHandler(&server.Config{})
+			require.Error(t, err)
+			assert.EqualError(t, err, "invalid config: masquerade.proxy.url: "+test.wantErr)
+		})
+	}
+}
+
+func TestMasqueradeProxyKeepsExistingMalformedHTTPBehavior(t *testing.T) {
+	config := &serverConfig{Masquerade: serverConfigMasquerade{
+		Type:  "proxy",
+		Proxy: serverConfigMasqueradeProxy{URL: "http:/127.0.0.1:8923"},
+	}}
+	assert.NoError(t, config.fillMasqHandler(&server.Config{}))
+}
+
+func TestMasqueradeProxyHTTPRegression(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "front.example", r.Host)
+		assert.Equal(t, "/health", r.URL.Path)
+		_, _ = w.Write([]byte("healthy"))
+	}))
+	defer upstream.Close()
+
+	handler, err := newMasqueradeProxyHandler(serverConfigMasqueradeProxy{URL: upstream.URL})
+	require.NoError(t, err)
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "https://front.example/health", nil)
+	req.Host = "front.example"
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "healthy", recorder.Body.String())
+}


### PR DESCRIPTION
## Summary

Add Unix domain socket upstream support to `masquerade.proxy`.

## Motivation

Local upstream services may listen on Unix sockets instead of TCP ports. Supporting UDS provides a more efficient forwarding path for services running on the same host.

## What's New

- Support the following `masquerade.proxy.url` formats:
  - `/run/anubis/anubis.sock`
  - `unix:/run/anubis/anubis.sock`
  - `unix:///run/anubis/anubis.sock`
- Reuse Unix socket connections through the HTTP transport pool.
- Preserve existing HTTP/HTTPS, `rewriteHost`, `xForwarded`, path, query, and error-handling behavior.
- Add tests and benchmarks for Unix socket proxying.

## Example

```yaml
masquerade:
  type: proxy
  proxy:
    url: unix:///run/anubis/anubis.sock
    rewriteHost: false
    xForwarded: true
  listenHTTPS: :443
  forceHTTPS: true
```

A plain absolute path is also supported:

```yaml
proxy:
  url: /run/anubis/anubis.sock
```

## Tests

- `python3 hyperbole.py format`
- `python3 hyperbole.py tidy`
- `python3 hyperbole.py mockgen`
- `python3 hyperbole.py test core`
- `go test ./cmd`
- `go vet ./cmd`