### PR TITLE
fix: plain HTTP requests through the HTTP proxy cut off after 10 seconds

### DIFF
--- a/app/internal/http/server.go
+++ b/app/internal/http/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	httpClientTimeout = 10 * time.Second
+	httpResponseHeaderTimeout = 10 * time.Second
 )
 
 // Server is an HTTP server using a Hysteria client as outbound.
@@ -235,11 +235,11 @@ func (s *Server) initHTTPClient() {
 				// HyClient doesn't support context for now
 				return s.HyClient.TCP(addr)
 			},
+			ResponseHeaderTimeout: httpResponseHeaderTimeout,
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
-		Timeout: httpClientTimeout,
 	}
 }
 


### PR DESCRIPTION
Fixes #1674

The client's HTTP inbound fetched plain `http://` URLs with an `http.Client` that had `Timeout: 10s`. That field is a wall-clock limit on the *entire* exchange, including reading the body — so any response taking longer than 10 s to stream was cancelled mid-transfer, regardless of progress. CONNECT and SOCKS5 were unaffected as they don't go through this client.

Replace it with `Transport.ResponseHeaderTimeout`, which bounds only the dial and the wait for response headers. The body can now take as long as it takes, matching how the HTTP/SOCKS5 outbounds already scope their handshake deadlines.